### PR TITLE
Update Sublime ts files name to match the current

### DIFF
--- a/src/editorManager.ts
+++ b/src/editorManager.ts
@@ -1,6 +1,6 @@
 import Atom from './editors/atom'
-import SublimeText2 from './editors/sublime-text2'
-import SublimeText3 from './editors/sublime-text3'
+import SublimeText2 from './editors/sublimeText2'
+import SublimeText3 from './editors/sublimeText3'
 import Vim from './editors/vim'
 
 


### PR DESCRIPTION
The name of Sublime Text ts files is not identical with the actual file name, which generate error while running npm run build