### PR TITLE
bug: fix TS bug on building phase for ipcRenderer messages

### DIFF
--- a/src/stores/rendererStore.ts
+++ b/src/stores/rendererStore.ts
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware, compose } from "redux";
-import { ipcRenderer } from "electron";
+import { ipcRenderer, IpcRendererEvent } from "electron";
 import crashReporter from "../middlewares/crashReporter";
 import logger from "../middlewares/logger";
 import forwardToMain from "../middlewares/forwardToMain";
@@ -22,7 +22,7 @@ const onFetchMainStoreState = () => {
   store.dispatch(onRenderStoreCreated());
 };
 onFetchMainStoreState();
-ipcRenderer.on("message", (event: string, message) => {
+ipcRenderer.on("message", (event: IpcRendererEvent, message) => {
   console.log("[on message]", event, message);
   onFetchMainStoreState();
 });


### PR DESCRIPTION
There is a TS error on building phase, this PR fixes it by importing the correct interface for the ipcRenderer message event 

This was the error
```
ERROR in /Users/sebastian.velez/Desktop/TEMP/desktop/src/stores/rendererStore.ts
    [tsl] ERROR in /Users/sebastian.velez/Desktop/TEMP/desktop/src/stores/rendererStore.ts(25,27)
          TS2345: Argument of type '(event: string, message: any) => void' is not assignable to parameter of type '(event: IpcRendererEvent, ...args: any[]) => void'.
      Types of parameters 'event' and 'event' are incompatible.
        Type 'IpcRendererEvent' is not assignable to type 'string'.
```