### PR TITLE
fix VS testing for darwin by mocking the VS path

### DIFF
--- a/test/visual-studio.spec.ts
+++ b/test/visual-studio.spec.ts
@@ -8,7 +8,7 @@ const chaiAsPromised = require("chai-as-promised");
 const { expect } = chai;
 chai.use(chaiAsPromised);
 
-describe("Visual Studio Code", () => {
+describe("Visual Studio", () => {
   let visualStudio: VisualStudio;
   let getInstalledVersions: any;
   let isDirectory: any;

--- a/test/visual-studio.spec.ts
+++ b/test/visual-studio.spec.ts
@@ -11,10 +11,12 @@ chai.use(chaiAsPromised);
 describe("Visual Studio Code", () => {
   let visualStudio: VisualStudio;
   let getInstalledVersions: any;
+  let isDirectory: any;
 
   beforeEach(() => {
     visualStudio = new VisualStudio();
     getInstalledVersions = sinon.stub(visualStudio, "getInstalledVersions");
+    isDirectory = sinon.stub(visualStudio, "isDirectory");
   });
   afterEach(() => {
     getInstalledVersions.restore();
@@ -29,11 +31,13 @@ describe("Visual Studio Code", () => {
   });
   it("should return TRUE if editor is installed", async () => {
     getInstalledVersions.returns([2010, 2012]);
+    isDirectory.returns(true);
     const result = await visualStudio.isEditorInstalled();
     expect(result).to.be.true;
   });
   it("should return FALSE if editor is not installed", async () => {
     getInstalledVersions.returns([]);
+    isDirectory.returns(false);
     const result = await visualStudio.isEditorInstalled();
     expect(result).to.be.false;
   });


### PR DESCRIPTION
* Fixes testing on `darwin` OS
* Fixes the describe block from VScode to VS that is the correct one

pending PR to fix testing for Android Studio...

![image](https://user-images.githubusercontent.com/1050904/65286284-a2408400-db04-11e9-9e50-3094df92604b.png)
