### PR TITLE
centralized logger

### DIFF
--- a/src/containers/index.tsx
+++ b/src/containers/index.tsx
@@ -7,9 +7,12 @@ import { render } from 'react-dom';
 import Tray from '../components/tray-menu/Tray';
 import store from '../stores/rendererStore';
 import isMainProcess from '../utils/isMainProcess';
+import logger from '../utils/logger';
 
-console.log('isMainProcess', isMainProcess);
 const div = document.getElementById('container');
+
+logger.debug(`isMainProcess ${isMainProcess ? 'true' : 'false'}`);
+
 if (div) {
   render(
     <Provider store={store}>

--- a/src/editors/android-studio.ts
+++ b/src/editors/android-studio.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { CommandExists } from '../lib/command-exists';
 import Editor from './editor';
 import { installJetbrainsPlugin, unInstallJetbrainsPlugin } from '../utils/jetbrains';
+import logger from '../utils/logger';
 
 const plist = require('plist');
 
@@ -40,7 +41,7 @@ export default class AndroidStudio extends Editor {
       if (ret) return true;
       return this.isDirectorySync(this.appDirectory());
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }

--- a/src/editors/atom.ts
+++ b/src/editors/atom.ts
@@ -6,6 +6,7 @@ import request from 'request';
 
 import { CommandExists } from '../lib/command-exists';
 import Editor from './editor';
+import logger from '../utils/logger';
 
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
@@ -33,7 +34,7 @@ export default class Atom extends Editor {
     try {
       return (await this.isBinary(this.binary)) || this.isDirectorySync(this.appDirectory());
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }
@@ -44,7 +45,7 @@ export default class Atom extends Editor {
     try {
       return await this.apm();
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }
@@ -86,11 +87,11 @@ export default class Atom extends Editor {
           });
         })
         .on('error', (err: any) => {
-          console.error(err);
+          logger.error(err);
           reject(err);
         });
-    }).catch(err => {
-      console.error(err);
+    }).catch((err) => {
+      logger.error(err);
     });
   }
 
@@ -141,7 +142,7 @@ export default class Atom extends Editor {
     if (stderr) return Promise.reject(new Error(stderr));
 
     const json = JSON.parse(stdout);
-    const obj = json.user.find(n => n.name === 'wakatime');
+    const obj = json.user.find((n) => n.name === 'wakatime');
     return Promise.resolve(obj !== undefined);
   }
 }

--- a/src/editors/azure-data-studio.ts
+++ b/src/editors/azure-data-studio.ts
@@ -1,5 +1,7 @@
 import os from 'os';
+
 import Editor from './editor';
+import logger from '../utils/logger';
 
 export default class AzureDataStudio extends Editor {
   public static getName(): string {
@@ -18,7 +20,7 @@ export default class AzureDataStudio extends Editor {
     try {
       return this.isDirectorySync(this.appDirectory());
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }

--- a/src/editors/blender.ts
+++ b/src/editors/blender.ts
@@ -4,6 +4,7 @@ import fsSync from 'fs';
 
 import Editor from './editor';
 import CommandExists from '../lib/command-exists';
+import logger from '../utils/logger';
 
 export default class Blender extends Editor {
   private commandExists = new CommandExists();
@@ -28,7 +29,7 @@ export default class Blender extends Editor {
     try {
       return await this.isBinary(this.binary);
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }

--- a/src/editors/chrome.ts
+++ b/src/editors/chrome.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import fs from 'fs';
 
 import Editor from './editor';
+import logger from '../utils/logger';
 
 export default class Chrome extends Editor {
   public static getName(): string {
@@ -39,7 +40,7 @@ export default class Chrome extends Editor {
       fs.unlinkSync(this.pluginsDirectory());
       return Promise.resolve();
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return Promise.reject();
     }
   }

--- a/src/editors/coda.ts
+++ b/src/editors/coda.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 
 import Editor from './editor';
+import logger from '../utils/logger';
 
 export default class Coda extends Editor {
   public static getName(): string {
@@ -17,22 +18,22 @@ export default class Coda extends Editor {
 
   public async isEditorInstalled(): Promise<boolean> {
     try {
-      return this.appDirectory().some(directory => {
+      return this.appDirectory().some((directory) => {
         return this.isDirectorySync(directory);
       });
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }
 
   public async isPluginInstalled(): Promise<boolean> {
     try {
-      return this.pluginsDirectory().some(directory => {
+      return this.pluginsDirectory().some((directory) => {
         return this.fileExistsSync(directory);
       });
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }

--- a/src/editors/eclipse.ts
+++ b/src/editors/eclipse.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import request from 'request';
 
 import Editor from './editor';
+import logger from '../utils/logger';
 
 export default class Eclipse extends Editor {
   public static getName(): string {
@@ -53,11 +54,11 @@ export default class Eclipse extends Editor {
           resolve();
         })
         .on('error', (err: any) => {
-          console.error(err);
+          logger.error(err);
           reject(err);
         });
-    }).catch(err => {
-      console.error(err);
+    }).catch((err) => {
+      logger.error(err);
     });
   }
 
@@ -66,7 +67,7 @@ export default class Eclipse extends Editor {
       fs.unlinkSync(`${os.homedir()}/.p2/pool/plugins/${this.pluginVersion}`);
       return Promise.resolve();
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return Promise.reject();
     }
   }
@@ -85,7 +86,7 @@ export default class Eclipse extends Editor {
 
   private directory(directories: Array<string>): string {
     let directory = '';
-    directories.some(pluginPath => {
+    directories.some((pluginPath) => {
       if (this.isDirectorySync(pluginPath)) {
         directory = pluginPath;
         return true;
@@ -101,7 +102,7 @@ export default class Eclipse extends Editor {
         return [''];
       }
       case 'darwin':
-        return this.versions.map(check => `${os.homedir()}/eclipse/java-${check}`);
+        return this.versions.map((check) => `${os.homedir()}/eclipse/java-${check}`);
       case 'linux':
         return [''];
       default:

--- a/src/editors/editor.ts
+++ b/src/editors/editor.ts
@@ -17,7 +17,6 @@ export default abstract class Editor implements EditorInterface {
       const stats = await stat(directory);
       return stats.isDirectory();
     } catch (err) {
-      // console.error(err);
       return false;
     }
   }
@@ -27,7 +26,6 @@ export default abstract class Editor implements EditorInterface {
       const stats = fs.statSync(directory);
       return stats.isDirectory();
     } catch (err) {
-      // console.error(err);
       return false;
     }
   }
@@ -42,7 +40,6 @@ export default abstract class Editor implements EditorInterface {
       const stats = fs.statSync(filePath);
       return stats.isFile();
     } catch (err) {
-      // console.error(err);
       return false;
     }
   }
@@ -51,7 +48,6 @@ export default abstract class Editor implements EditorInterface {
     try {
       return fs.existsSync(file);
     } catch (err) {
-      // console.error(err);
       return false;
     }
   }

--- a/src/editors/eric.ts
+++ b/src/editors/eric.ts
@@ -5,6 +5,7 @@ import request from 'request';
 
 import Editor from './editor';
 import { CommandExists } from '../lib/command-exists';
+import logger from '../utils/logger';
 
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
@@ -35,12 +36,12 @@ export default class Eric extends Editor {
 
   public async isPluginInstalled(): Promise<boolean> {
     try {
-      return this.pluginsDirectory().some(directory => {
+      return this.pluginsDirectory().some((directory) => {
         const pluginPath = path.join(directory, 'PluginWakaTime.py');
         return this.fileExistsSync(pluginPath);
       });
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }
@@ -62,7 +63,7 @@ export default class Eric extends Editor {
         .pipe(file)
         .on('finish', async () => {
           const pluginsDirectories = this.pluginsDirectory();
-          pluginsDirectories.forEach(async directory => {
+          pluginsDirectories.forEach(async (directory) => {
             const fileStream = fs.createWriteStream(path.join(directory, 'PluginWakaTime.py'));
             const stream2 = await fs.createReadStream(temp);
             await stream2.pipe(fileStream);
@@ -71,16 +72,16 @@ export default class Eric extends Editor {
           resolve();
         })
         .on('error', (err: any) => {
-          console.error(err);
+          logger.error(err);
           reject(err);
         });
-    }).catch(err => {
-      console.error(err);
+    }).catch((err) => {
+      logger.error(err);
     });
   }
 
   public async uninstallPlugin(): Promise<void> {
-    this.pluginsDirectory().forEach(async directory => {
+    this.pluginsDirectory().forEach(async (directory) => {
       const pluginPath = path.join(directory, 'PluginWakaTime.py');
       await fs.unlinkSync(pluginPath);
     });

--- a/src/editors/intellij.ts
+++ b/src/editors/intellij.ts
@@ -2,6 +2,7 @@ import os from 'os';
 
 import Editor from './editor';
 import { installJetbrainsPlugin, unInstallJetbrainsPlugin } from '../utils/jetbrains';
+import logger from '../utils/logger';
 
 export default class AppCode extends Editor {
   public static getName(): string {
@@ -22,11 +23,11 @@ export default class AppCode extends Editor {
 
   public async isEditorInstalled(): Promise<boolean> {
     try {
-      return this.appDirectory().some(directory => {
+      return this.appDirectory().some((directory) => {
         return this.isDirectorySync(directory);
       });
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }
@@ -50,8 +51,8 @@ export default class AppCode extends Editor {
     let IdeaIC = [];
     switch (os.platform()) {
       case 'win32':
-        intelliJIdea = pathsToCheck.map(check => `${os.homedir()}\\.IntelliJIdea${check}`);
-        IdeaIC = pathsToCheck.map(check => `${os.homedir()}\\.IdeaIC${check}`);
+        intelliJIdea = pathsToCheck.map((check) => `${os.homedir()}\\.IntelliJIdea${check}`);
+        IdeaIC = pathsToCheck.map((check) => `${os.homedir()}\\.IdeaIC${check}`);
         directories.push(this.directory(intelliJIdea));
         directories.push(this.directory(IdeaIC));
         return directories;
@@ -81,7 +82,7 @@ export default class AppCode extends Editor {
 
   private directory(directories: Array<string>): string {
     let directory = '';
-    directories.some(pluginPath => {
+    directories.some((pluginPath) => {
       if (this.isDirectorySync(pluginPath)) {
         directory = pluginPath;
         return true;
@@ -98,17 +99,17 @@ export default class AppCode extends Editor {
     switch (os.platform()) {
       case 'win32': {
         intelliJIdea = pathsToCheck.map(
-          path => `${os.homedir()}\\.IntelliJIdea${path}\\config\\plugins`,
+          (path) => `${os.homedir()}\\.IntelliJIdea${path}\\config\\plugins`,
         );
-        IdeaIC = pathsToCheck.map(path => `${os.homedir()}\\.IdeaIC${path}\\config\\plugins`);
+        IdeaIC = pathsToCheck.map((path) => `${os.homedir()}\\.IdeaIC${path}\\config\\plugins`);
         return intelliJIdea.concat(IdeaIC);
       }
       case 'darwin':
         intelliJIdea = pathsToCheck.map(
-          path => `${os.homedir()}/Library/Application Support/IntelliJIdea${path}`,
+          (path) => `${os.homedir()}/Library/Application Support/IntelliJIdea${path}`,
         );
         IdeaIC = pathsToCheck.map(
-          path => `${os.homedir()}/Library/Application Support/IdeaIC${path}`,
+          (path) => `${os.homedir()}/Library/Application Support/IdeaIC${path}`,
         );
         return intelliJIdea.concat(IdeaIC);
       case 'linux':

--- a/src/editors/kakoune.ts
+++ b/src/editors/kakoune.ts
@@ -5,6 +5,7 @@ import request from 'request';
 
 import Editor from './editor';
 import { CommandExists } from '../lib/command-exists';
+import logger from '../utils/logger';
 
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
@@ -57,11 +58,11 @@ export default class Kakoune extends Editor {
           resolve();
         })
         .on('error', (err: any) => {
-          console.error(err);
+          logger.error(err);
           reject(err);
         });
-    }).catch(err => {
-      console.error(err);
+    }).catch((err) => {
+      logger.error(err);
     });
   }
 

--- a/src/editors/processing.ts
+++ b/src/editors/processing.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import request from 'request';
 
 import Editor from './editor';
+import logger from '../utils/logger';
 
 export default class Processing extends Editor {
   private preferences: { [key: string]: string } = {};
@@ -62,11 +63,11 @@ export default class Processing extends Editor {
           });
         })
         .on('error', (err: any) => {
-          console.error(err);
+          logger.error(err);
           reject(err);
         });
-    }).catch(err => {
-      console.error(err);
+    }).catch((err) => {
+      logger.error(err);
     });
   }
 
@@ -96,7 +97,7 @@ export default class Processing extends Editor {
         if (this.fileExistsSync(file)) {
           const data = fs.readFileSync(file, { encoding: 'utf8' });
           if (data) {
-            data.split(/\r?\n/).forEach(line => {
+            data.split(/\r?\n/).forEach((line) => {
               const split = line.split('=');
               this.preferences[split[0]] = split[1];
             });

--- a/src/editors/sublime-text-2.ts
+++ b/src/editors/sublime-text-2.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import request from 'request';
 
 import Editor from './editor';
+import logger from '../utils/logger';
 
 export default class SublimeText2 extends Editor {
   public static getName(): string {
@@ -60,11 +61,11 @@ export default class SublimeText2 extends Editor {
           });
         })
         .on('error', (err: any) => {
-          console.error(err);
+          logger.error(err);
           reject(err);
         });
-    }).catch(err => {
-      console.error(err);
+    }).catch((err) => {
+      logger.error(err);
     });
   }
 

--- a/src/editors/sublime-text-3.ts
+++ b/src/editors/sublime-text-3.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import request from 'request';
 
 import Editor from './editor';
+import logger from '../utils/logger';
 
 export default class SublimeText3 extends Editor {
   public static getName(): string {
@@ -60,11 +61,11 @@ export default class SublimeText3 extends Editor {
           });
         })
         .on('error', (err: any) => {
-          console.error(err);
+          logger.error(err);
           reject(err);
         });
-    }).catch(err => {
-      console.error(err);
+    }).catch((err) => {
+      logger.error(err);
     });
   }
 

--- a/src/editors/texstudio.ts
+++ b/src/editors/texstudio.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import request from 'request';
 
 import Editor from './editor';
+import logger from '../utils/logger';
 
 const python = require('child_process');
 
@@ -46,24 +47,24 @@ export default class TeXstudio extends Editor {
         .on('finish', async () => {
           python.spawn('python', [temp]);
           let output = '';
-          python.stdout.on('data', data => {
+          python.stdout.on('data', (data) => {
             output += data;
           });
-          python.on('close', code => {
+          python.on('close', (code) => {
             if (code !== 0) {
-              console.error(code);
+              logger.error(code);
             }
           });
-          console.log(output);
+          logger.debug(output);
           fs.unlinkSync(temp);
           resolve();
         })
         .on('error', (err: any) => {
-          console.error(err);
+          logger.error(err);
           reject(err);
         });
-    }).catch(err => {
-      console.error(err);
+    }).catch((err) => {
+      logger.error(err);
     });
   }
 
@@ -75,7 +76,7 @@ export default class TeXstudio extends Editor {
       }
       return Promise.resolve();
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return Promise.reject();
     }
   }
@@ -105,9 +106,9 @@ export default class TeXstudio extends Editor {
   private findMacroFile(): string {
     let macrofile = '';
     fs.readdirSync(this.pluginsDirectory(), { withFileTypes: true })
-      .filter(dirent => !dirent.isDirectory())
-      .map(dirent => dirent.name)
-      .some(file => {
+      .filter((dirent) => !dirent.isDirectory())
+      .map((dirent) => dirent.name)
+      .some((file) => {
         const fileContent = fs.readFileSync(path.join(this.pluginsDirectory(), file), 'utf8');
         const json = this.readJsonContent(fileContent);
         if (json !== '' && json.name === 'WakaTime') {

--- a/src/editors/vim.ts
+++ b/src/editors/vim.ts
@@ -1,5 +1,6 @@
 import Editor from './editor';
 import { CommandExists } from '../lib/command-exists';
+import logger from '../utils/logger';
 
 export default class Vim extends Editor {
   private commandExists = new CommandExists();
@@ -24,7 +25,7 @@ export default class Vim extends Editor {
     try {
       let exists = false;
       await Promise.all(
-        Object.keys(this.binaries).map(async binary => {
+        Object.keys(this.binaries).map(async (binary) => {
           if (await this.isBinary(binary)) {
             exists = true;
           }
@@ -32,7 +33,7 @@ export default class Vim extends Editor {
       );
       return exists;
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }

--- a/src/editors/vscode.ts
+++ b/src/editors/vscode.ts
@@ -2,6 +2,7 @@ import os from 'os';
 
 import { CommandExists } from '../lib/command-exists';
 import Editor from './editor';
+import logger from '../utils/logger';
 
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
@@ -29,18 +30,18 @@ export default class VsCode extends Editor {
     try {
       let exists = false;
       await Promise.all(
-        Object.keys(this.binaries).map(async binary => {
+        Object.keys(this.binaries).map(async (binary) => {
           if (await this.isBinary(binary)) {
             exists = true;
           }
         }),
       );
       if (exists) return true;
-      return this.appDirectory().some(directory => {
+      return this.appDirectory().some((directory) => {
         return this.isDirectorySync(directory);
       });
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }

--- a/src/editors/xcode.ts
+++ b/src/editors/xcode.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import { CommandExists } from '../lib/command-exists';
 import Editor from './editor';
+import logger from '../utils/logger';
 
 export default class Xcode extends Editor {
   private commandExists = new CommandExists();
@@ -27,7 +28,7 @@ export default class Xcode extends Editor {
     try {
       let exists = false;
       await Promise.all(
-        Object.keys(this.binaries).map(async binary => {
+        Object.keys(this.binaries).map(async (binary) => {
           if (await this.isBinary(binary)) {
             exists = true;
           }
@@ -36,7 +37,7 @@ export default class Xcode extends Editor {
       if (exists) return true;
       return await this.isDirectory(this.appDirectory());
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       return false;
     }
   }

--- a/src/middlewares/crashReporter.ts
+++ b/src/middlewares/crashReporter.ts
@@ -1,12 +1,14 @@
 import { Store, Dispatch, Action } from 'redux';
 
+import logger from '../utils/logger';
+
 const crashReporter = (store: Store) => (next: Dispatch) => (action: Action) => {
   let result;
   try {
     result = next(action);
   } catch (err) {
     // This will not trigger when the chrome redux extension takes control
-    console.error(
+    logger.error(
       'Uncaught exception:',
       err,
       '/naction:',

--- a/src/middlewares/forwardToRenderer.ts
+++ b/src/middlewares/forwardToRenderer.ts
@@ -1,14 +1,16 @@
 /* eslint-disable no-undef */
 import { Store, Dispatch, Action } from 'redux';
+
 import isMainProcess from '../utils/isMainProcess';
 import isForwardToRendererAction from '../utils/isForwardToRendererAction';
+import logger from '../utils/logger';
 
 let wins = [];
-export const registerWindow = win => {
+export const registerWindow = (win) => {
   wins.push(win);
 };
-export const unRegisterWindow = win => {
-  wins = wins.filter(w => w !== win);
+export const unRegisterWindow = (win) => {
+  wins = wins.filter((w) => w !== win);
 };
 
 const forwardToMain = (store: Store) => (next: Dispatch) => (action: Action) => {
@@ -16,8 +18,8 @@ const forwardToMain = (store: Store) => (next: Dispatch) => (action: Action) => 
 
   if (isMainProcess && isForwardToRendererAction(action)) {
     const msgArgs = ['message', store.getState()];
-    wins.forEach(w => {
-      console.log('forwarding message', w);
+    wins.forEach((w) => {
+      logger.debug(`forwarding message ${w}`);
       w.webContents.send(...msgArgs);
     });
   }

--- a/src/stores/rendererStore.ts
+++ b/src/stores/rendererStore.ts
@@ -1,10 +1,12 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import { ipcRenderer, IpcRendererEvent } from 'electron';
+
 import crashReporter from '../middlewares/crashReporter';
-import logger from '../middlewares/logger';
+import reduxLogger from '../middlewares/logger';
 import forwardToMain from '../middlewares/forwardToMain';
 import rootReducer from '../reducers/renderProc';
 import { onRenderStoreCreated } from '../actions/rendererActions';
+import logger from '../utils/logger';
 
 let composeEnhancers = compose;
 // @ts-ignore
@@ -16,14 +18,14 @@ const initialState = {};
 const store = createStore(
   rootReducer,
   initialState,
-  composeEnhancers(applyMiddleware(forwardToMain, logger, crashReporter)),
+  composeEnhancers(applyMiddleware(forwardToMain, reduxLogger, crashReporter)),
 );
 const onFetchMainStoreState = () => {
   store.dispatch(onRenderStoreCreated());
 };
 onFetchMainStoreState();
 ipcRenderer.on('message', (event: IpcRendererEvent, message) => {
-  console.log('[on message]', event, message);
+  logger.debug(`[on message] ${event} ${message}`);
   onFetchMainStoreState();
 });
 export default store;

--- a/src/utils/jetbrains.ts
+++ b/src/utils/jetbrains.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import request from 'request';
 
+import logger from './logger';
+
 /**
  * Installs WakaTime plugin for Jetbrains editors
  * Directories used by the IDE to store settings go here
@@ -27,11 +29,11 @@ export const installJetbrainsPlugin = async (pluginsDirectory: string): Promise<
         resolve();
       })
       .on('error', (err: any) => {
-        console.error(err);
+        logger.error(err);
         reject(err);
       });
-  }).catch(err => {
-    console.error(err);
+  }).catch((err) => {
+    logger.error(err);
   });
 };
 
@@ -44,7 +46,7 @@ export const unInstallJetbrainsPlugin = async (pluginsDirectory: string): Promis
     fs.unlinkSync(`${pluginsDirectory}/WakaTime.jar`);
     return Promise.resolve();
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     return Promise.reject();
   }
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,58 @@
+export enum LogLevel {
+  DEBUG = 0,
+  INFO,
+  WARN,
+  ERROR,
+}
+
+class Logger {
+  private level: LogLevel;
+
+  constructor(level: LogLevel = LogLevel.INFO) {
+    this.setLevel(level);
+  }
+
+  public getLevel(): LogLevel {
+    return this.level;
+  }
+
+  public setLevel(level: LogLevel): void {
+    this.level = level;
+  }
+
+  public log(level: LogLevel, msg: string, ...params: any): void {
+    if (level >= this.level) {
+      const message = `[WakaTime][${LogLevel[level]}] ${msg}`;
+      if (params.length > 0) {
+        if (level === LogLevel.DEBUG) console.log(message, ...params);
+        if (level === LogLevel.INFO) console.info(message, ...params);
+        if (level === LogLevel.WARN) console.warn(message, ...params);
+        if (level === LogLevel.ERROR) console.error(message, ...params);
+      } else {
+        if (level === LogLevel.DEBUG) console.log(message);
+        if (level === LogLevel.INFO) console.info(message);
+        if (level === LogLevel.WARN) console.warn(message);
+        if (level === LogLevel.ERROR) console.error(message);
+      }
+    }
+  }
+
+  public debug(msg: string, ...params: any): void {
+    this.log(LogLevel.DEBUG, msg, ...params);
+  }
+
+  public info(msg: string, ...params: any): void {
+    this.log(LogLevel.INFO, msg, ...params);
+  }
+
+  public warn(msg: string, ...params: any): void {
+    this.log(LogLevel.WARN, msg, ...params);
+  }
+
+  public error(msg: string, ...params: any): void {
+    this.log(LogLevel.ERROR, msg, ...params);
+  }
+}
+
+const logger = new Logger();
+export default logger;

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 
 import { ExpirationStrategy } from './cache/expiration-strategy';
 import { MemoryStorage } from './cache/memory-storage';
+import logger from './logger';
 
 export default class Options {
   private configFile: string;
@@ -92,7 +93,7 @@ export default class Options {
         try {
           apiKey = await this.getSettingAsync<string>('settings', 'key');
         } catch (err) {
-          console.log('api key not found on config file');
+          logger.error('api key not found on config file');
         }
       }
     }


### PR DESCRIPTION
no more `console.log`
This is a step closer to log things to a centralized logger and send the logs to wakatime backend when the user chooses to report an issue